### PR TITLE
Support for Windows 11 Insider build 25158 and up

### DIFF
--- a/Module/VirtualDesktop.ps1
+++ b/Module/VirtualDesktop.ps1
@@ -280,9 +280,15 @@ $(if ($OSBuild -ge 22000) {@"
 
 	[ComImport]
 	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-$(if ($OSBuild -ge 22000) {@"
+$(if ($OSBuild -ge 25158) {@"
+// Windows 11 Insider:
+	[Guid("88846798-1611-4D18-946B-4A67BFF58C1B")]
+"@ })
+$(if (($OSBuild -ge 22000) -And ($OSBuild -lt 25158)) {@"
 // Windows 11:
 	[Guid("B2F925B9-5A0F-4D2E-9F4D-2B1507593C10")]
+"@ })
+$(if ($OSBuild -ge 22000) {@"
 	internal interface IVirtualDesktopManagerInternal
 	{
 		int GetCount(IntPtr hWndOrMon);
@@ -299,6 +305,10 @@ $(if ($OSBuild -ge 22000) {@"
 		[PreserveSig]
 		int GetAdjacentDesktop(IVirtualDesktop from, int direction, out IVirtualDesktop desktop);
 		void SwitchDesktop(IntPtr hWndOrMon, IVirtualDesktop desktop);
+$(if ($OSBuild -ge 25158) {@"
+// Windows 11 Insider:
+		void SwitchDesktopAndMoveForegroundView(IntPtr hWndOrMon, IVirtualDesktop desktop);
+"@ })
 		IVirtualDesktop CreateDesktop(IntPtr hWndOrMon);
 		void MoveDesktop(IVirtualDesktop desktop, IntPtr hWndOrMon, int nIndex);
 		void RemoveDesktop(IVirtualDesktop desktop, IVirtualDesktop fallback);


### PR DESCRIPTION
I have tested that `Get-DesktopList` and `Set-DesktopWallpaper` work after these changes on the dev channel 25276.

Other commands that I don't use have not been tested. Also the "25158 and up" is a guess based on [this commit message](https://github.com/dankrusi/WindowsVirtualDesktopHelper/commit/bc5b309c2b36b02689258f6caf17aa37f8403ed6).

Thanks to @NyaMisty for creating the GetVirtualDesktopAPI script that provided the necessary info to make these changes:
```
IID_IVirtualDesktopManagerInternal: 88846798-1611-4D18-946B-4A67BFF58C1B

Dumping vftable: const CVirtualDesktopManager::`vftable'{for `IVirtualDesktopManagerInternal'}
    Method  0: [thunk]:public: virtual long __cdecl Microsoft::WRL::Details::RuntimeClassImpl<struct Microsoft::WRL::RuntimeClassFlags<3>,1,1,0,struct Microsoft::WRL::ChainInterfaces<struct IVirtualDesktopManagerPrivate,struct IVirtualDesktopManagerInternal,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil>,struct IVirtualDesktopManagerInternal,struct ISuspendableVirtualDesktopManager,struct IImmersiveWindowMessageNotification,class Microsoft::WRL::FtmBase>::QueryInterface`adjustor{24}' (struct _GUID const & __ptr64,void * __ptr64 * __ptr64) __ptr64 (?QueryInterface@?$RuntimeClassImpl@U?$RuntimeClassFlags@$02@WRL@Microsoft@@$00$00$0A@U?$ChainInterfaces@UIVirtualDesktopManagerPrivate@@UIVirtualDesktopManagerInternal@@VNil@Details@WRL@Microsoft@@V3456@V3456@V3456@V3456@V3456@V3456@V3456@@23@UIVirtualDesktopManagerInternal@@UISuspendableVirtualDesktopManager@@UIImmersiveWindowMessageNotification@@VFtmBase@23@@Details@WRL@Microsoft@@WBI@EAAJAEBU_GUID@@PEAPEAX@Z)
    Method  1: [thunk]:public: virtual unsigned long __cdecl Microsoft::WRL::Details::RuntimeClassImpl<struct Microsoft::WRL::RuntimeClassFlags<3>,1,1,0,struct Microsoft::WRL::ChainInterfaces<struct IVirtualDesktopManagerPrivate,struct IVirtualDesktopManagerInternal,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil>,struct IVirtualDesktopManagerInternal,struct ISuspendableVirtualDesktopManager,struct IImmersiveWindowMessageNotification,class Microsoft::WRL::FtmBase>::AddRef`adjustor{24}' (void) __ptr64 (?AddRef@?$RuntimeClassImpl@U?$RuntimeClassFlags@$02@WRL@Microsoft@@$00$00$0A@U?$ChainInterfaces@UIVirtualDesktopManagerPrivate@@UIVirtualDesktopManagerInternal@@VNil@Details@WRL@Microsoft@@V3456@V3456@V3456@V3456@V3456@V3456@V3456@@23@UIVirtualDesktopManagerInternal@@UISuspendableVirtualDesktopManager@@UIImmersiveWindowMessageNotification@@VFtmBase@23@@Details@WRL@Microsoft@@WBI@EAAKXZ)
    Method  2: [thunk]:public: virtual unsigned long __cdecl Microsoft::WRL::Details::RuntimeClassImpl<struct Microsoft::WRL::RuntimeClassFlags<3>,1,1,0,struct Microsoft::WRL::ChainInterfaces<struct IVirtualDesktopManagerPrivate,struct IVirtualDesktopManagerInternal,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil,class Microsoft::WRL::Details::Nil>,struct IVirtualDesktopManagerInternal,struct ISuspendableVirtualDesktopManager,struct IImmersiveWindowMessageNotification,class Microsoft::WRL::FtmBase>::Release`adjustor{24}' (void) __ptr64 (?Release@?$RuntimeClassImpl@U?$RuntimeClassFlags@$02@WRL@Microsoft@@$00$00$0A@U?$ChainInterfaces@UIVirtualDesktopManagerPrivate@@UIVirtualDesktopManagerInternal@@VNil@Details@WRL@Microsoft@@V3456@V3456@V3456@V3456@V3456@V3456@V3456@@23@UIVirtualDesktopManagerInternal@@UISuspendableVirtualDesktopManager@@UIImmersiveWindowMessageNotification@@VFtmBase@23@@Details@WRL@Microsoft@@WBI@EAAKXZ)
    Method  3: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetCount`adjustor{16}' (struct HMONITOR__ * __ptr64,unsigned int * __ptr64) __ptr64 (?GetCount@CVirtualDesktopManager@@WBA@EAAJPEAUHMONITOR__@@PEAI@Z)
    Method  4: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::MoveViewToDesktop`adjustor{16}' (struct IApplicationView * __ptr64,struct IVirtualDesktop * __ptr64) __ptr64 (?MoveViewToDesktop@CVirtualDesktopManager@@WBA@EAAJPEAUIApplicationView@@PEAUIVirtualDesktop@@@Z)
    Method  5: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::CanViewMoveDesktops`adjustor{16}' (struct IApplicationView * __ptr64,int * __ptr64) __ptr64 (?CanViewMoveDesktops@CVirtualDesktopManager@@WBA@EAAJPEAUIApplicationView@@PEAH@Z)
    Method  6: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetCurrentDesktop`adjustor{16}' (struct HMONITOR__ * __ptr64,struct IVirtualDesktop * __ptr64 * __ptr64) __ptr64 (?GetCurrentDesktop@CVirtualDesktopManager@@WBA@EAAJPEAUHMONITOR__@@PEAPEAUIVirtualDesktop@@@Z)
    Method  7: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetAllCurrentDesktops`adjustor{16}' (struct IObjectArray * __ptr64 * __ptr64) __ptr64 (?GetAllCurrentDesktops@CVirtualDesktopManager@@WBA@EAAJPEAPEAUIObjectArray@@@Z)
    Method  8: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetDesktops`adjustor{16}' (struct HMONITOR__ * __ptr64,struct IObjectArray * __ptr64 * __ptr64) __ptr64 (?GetDesktops@CVirtualDesktopManager@@WBA@EAAJPEAUHMONITOR__@@PEAPEAUIObjectArray@@@Z)
    Method  9: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetAdjacentDesktop`adjustor{16}' (struct IVirtualDesktop * __ptr64,unsigned int,struct IVirtualDesktop * __ptr64 * __ptr64) __ptr64 (?GetAdjacentDesktop@CVirtualDesktopManager@@WBA@EAAJPEAUIVirtualDesktop@@IPEAPEAU2@@Z)
    Method 10: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::SwitchDesktop`adjustor{16}' (struct HMONITOR__ * __ptr64,struct IVirtualDesktop * __ptr64) __ptr64 (?SwitchDesktop@CVirtualDesktopManager@@WBA@EAAJPEAUHMONITOR__@@PEAUIVirtualDesktop@@@Z)
    Method 11: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::SwitchDesktopAndMoveForegroundView`adjustor{16}' (struct HMONITOR__ * __ptr64,struct IVirtualDesktop * __ptr64) __ptr64 (?SwitchDesktopAndMoveForegroundView@CVirtualDesktopManager@@WBA@EAAJPEAUHMONITOR__@@PEAUIVirtualDesktop@@@Z)
    Method 12: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::CreateDesktopW`adjustor{16}' (struct HMONITOR__ * __ptr64,struct IVirtualDesktop * __ptr64 * __ptr64) __ptr64 (?CreateDesktopW@CVirtualDesktopManager@@WBA@EAAJPEAUHMONITOR__@@PEAPEAUIVirtualDesktop@@@Z)
    Method 13: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::MoveDesktop`adjustor{16}' (struct IVirtualDesktop * __ptr64,struct HMONITOR__ * __ptr64,unsigned int) __ptr64 (?MoveDesktop@CVirtualDesktopManager@@WBA@EAAJPEAUIVirtualDesktop@@PEAUHMONITOR__@@I@Z)
    Method 14: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::RemoveDesktop`adjustor{16}' (struct IVirtualDesktop * __ptr64,struct IVirtualDesktop * __ptr64) __ptr64 (?RemoveDesktop@CVirtualDesktopManager@@WBA@EAAJPEAUIVirtualDesktop@@0@Z)
    Method 15: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::FindDesktop`adjustor{16}' (struct _GUID const & __ptr64,struct IVirtualDesktop * __ptr64 * __ptr64) __ptr64 (?FindDesktop@CVirtualDesktopManager@@WBA@EAAJAEBU_GUID@@PEAPEAUIVirtualDesktop@@@Z)
    Method 16: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetDesktopSwitchIncludeExcludeViews`adjustor{16}' (struct IVirtualDesktop * __ptr64,struct IObjectArray * __ptr64 * __ptr64,struct IObjectArray * __ptr64 * __ptr64) __ptr64 (?GetDesktopSwitchIncludeExcludeViews@CVirtualDesktopManager@@WBA@EAAJPEAUIVirtualDesktop@@PEAPEAUIObjectArray@@1@Z)
    Method 17: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::SetDesktopName`adjustor{16}' (struct IVirtualDesktop * __ptr64,struct HSTRING__ * __ptr64) __ptr64 (?SetDesktopName@CVirtualDesktopManager@@WBA@EAAJPEAUIVirtualDesktop@@PEAUHSTRING__@@@Z)
    Method 18: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::SetDesktopWallpaper`adjustor{16}' (struct IVirtualDesktop * __ptr64,struct HSTRING__ * __ptr64) __ptr64 (?SetDesktopWallpaper@CVirtualDesktopManager@@WBA@EAAJPEAUIVirtualDesktop@@PEAUHSTRING__@@@Z)
    Method 19: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::UpdateWallpaperPathForAllDesktops`adjustor{16}' (struct HSTRING__ * __ptr64) __ptr64 (?UpdateWallpaperPathForAllDesktops@CVirtualDesktopManager@@WBA@EAAJPEAUHSTRING__@@@Z)
    Method 20: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::CopyDesktopState`adjustor{16}' (struct IApplicationView * __ptr64,struct IApplicationView * __ptr64) __ptr64 (?CopyDesktopState@CVirtualDesktopManager@@WBA@EAAJPEAUIApplicationView@@0@Z)
    Method 21: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::GetDesktopIsPerMonitor`adjustor{16}' (int * __ptr64) __ptr64 (?GetDesktopIsPerMonitor@CVirtualDesktopManager@@WBA@EAAJPEAH@Z)
    Method 22: [thunk]:public: virtual long __cdecl CVirtualDesktopManager::SetDesktopIsPerMonitor`adjustor{16}' (int) __ptr64 (?SetDesktopIsPerMonitor@CVirtualDesktopManager@@WBA@EAAJH@Z)
```